### PR TITLE
Improve SNP matrix computation performance and data handling

### DIFF
--- a/bins/TK_SNPmat.py
+++ b/bins/TK_SNPmat.py
@@ -1,17 +1,16 @@
-from Bio.SeqRecord import SeqRecord
 from Bio import SeqIO
-from Bio.Seq import Seq
 import pandas as pd
 
-import sys#, getopt
 import argparse
-import os
 from pathlib import Path
 
 from itertools import combinations
-from multiprocessing import Process, Manager
+from multiprocessing import Pool
+from collections import defaultdict
 
-from OrthoSLC import __version__, mission_spliter
+import numpy as np
+
+from OrthoSLC import __version__
 
 p = argparse.ArgumentParser(
     prog="python3 TK_SNPmat.py",
@@ -39,85 +38,88 @@ args, extras = p.parse_known_args()
 
 kaligned_path = args.input_path
 
-def get_distance(str1, str2):
-    if str1 == str2:
-        return 0
-    d = 0
-    l = len(str1)
-    
-    for c in range(l):
-        if str1[c] != str2[c]:
-            d = d + 1
-            
-    return d
+def _init_worker(base_path, species_order):
+    """Store shared configuration for worker processes."""
+    global _KALIGNED_PATH, _SPECIES_ORDER, _PAIR_INDEX
 
-def distance_in_one_cluster(in_path_ls, 
-                            share_ls, 
-                            loop_ls, 
-                            total_len):
-    for in_path in in_path_ls:
-        in_fasta = SeqIO.to_dict(SeqIO.parse(kaligned_path + '/' + in_path,
-                                             'fasta'))
+    _KALIGNED_PATH = base_path
+    _SPECIES_ORDER = species_order
+    _PAIR_INDEX = [(i, j) for i in range(len(species_order))
+                   for j in range(i + 1, len(species_order))]
 
 
-        spe_dict = {x[0:x.index('-')]:x for x in in_fasta.keys()} # !!!!!!!!!!!!!
+def _encode_sequence(sequence):
+    """Convert a nucleotide sequence into a numpy byte array."""
+    encoded = np.frombuffer(sequence.upper().encode("ascii"), dtype="S1")
+    return encoded
 
-        result_dict = {}
 
-        for x in loop_ls:
-            snp=get_distance(str(in_fasta[spe_dict[x[0]]].seq),
-                             str(in_fasta[spe_dict[x[1]]].seq)
-                            )
-            result_dict[x] = snp
+def _process_alignment(filename):
+    """Compute pairwise SNP counts for a single alignment file."""
+    filepath = Path(_KALIGNED_PATH) / filename
+    fasta_records = SeqIO.to_dict(SeqIO.parse(filepath, "fasta"))
 
-        cluster_len = len(str(in_fasta[spe_dict[x[1]]].seq))
+    sequence_bytes = {}
+    for record_id, record in fasta_records.items():
+        if "-" not in record_id:
+            raise ValueError(
+                f"Record id '{record_id}' in '{filepath}' does not contain '-' separator."
+            )
+        species_id = record_id.split("-", 1)[0]
+        sequence_bytes[species_id] = _encode_sequence(str(record.seq))
 
-        total_len.append(cluster_len)
-        share_ls.append(result_dict)
+    missing_species = [sid for sid in _SPECIES_ORDER if sid not in sequence_bytes]
+    if missing_species:
+        raise KeyError(
+            f"Alignment '{filepath}' is missing sequences for: {', '.join(missing_species)}"
+        )
+
+    seq_len_set = {len(seq) for seq in sequence_bytes.values()}
+    if len(seq_len_set) != 1:
+        raise ValueError(
+            f"Alignment '{filepath}' contains sequences with inconsistent lengths: {seq_len_set}"
+        )
+
+    ordered_matrix = np.vstack([sequence_bytes[sid] for sid in _SPECIES_ORDER])
+    # Compute pairwise Hamming distances using vectorized comparison
+    diff_matrix = ordered_matrix[:, None, :] != ordered_matrix[None, :, :]
+    snp_matrix = diff_matrix.sum(axis=2, dtype=np.int32)
+
+    pair_counts = {
+        (_SPECIES_ORDER[i], _SPECIES_ORDER[j]): int(snp_matrix[i, j])
+        for i, j in _PAIR_INDEX
+    }
+
+    return pair_counts, ordered_matrix.shape[1]
 
 if __name__ == '__main__':
     procc_num = int(args.resource_total)
-    
-    mission_ls = mission_spliter(os.listdir(kaligned_path), procc_num)
-    
-    manager = Manager()
-    return_dict_ls = manager.list()
-    len_ls = manager.list()
-    
-    a_fasta = SeqIO.parse(kaligned_path + '/' + os.listdir(kaligned_path)[0], 'fasta')
-    a_ls = [x.id[0: x.id.index('-')] for x in a_fasta]
-    a_ls.sort()
-    
-    par_ls = list(combinations(a_ls, 2))
-    
-    for submissions in mission_ls:
-    
-        jobs = []
 
-        p = Process(target = distance_in_one_cluster,
-                    args = (submissions, 
-                            return_dict_ls,
-                            par_ls,
-                            len_ls
-                           )
+    kaligned_dir = Path(kaligned_path)
+    input_files = sorted(
+        [f.name for f in kaligned_dir.iterdir() if f.is_file() and not f.name.startswith('.')]
+    )
 
-                   )
-        p.start()
-        jobs.append(p)
+    if not input_files:
+        raise FileNotFoundError(f"No alignment files found under '{kaligned_path}'.")
 
+    first_file = kaligned_dir / input_files[0]
+    species_ids = sorted(
+        record.id.split("-", 1)[0]
+        for record in SeqIO.parse(first_file, "fasta")
+    )
 
-    for z in jobs:
-        z.join()
-    return_dict_ls = list(return_dict_ls)
+    worker_count = max(1, min(procc_num, len(input_files)))
 
-#add up all the snp number
-sum_snp = {}
-for key in return_dict_ls[0]: #prepare a dict to save snp number
-    sum_snp[key] = 0
-    
-for i in return_dict_ls:
-    for key in sum_snp:
-        sum_snp[key] = sum_snp[key] + i[key]
+    with Pool(processes=worker_count, initializer=_init_worker,
+              initargs=(str(kaligned_dir), species_ids)) as pool:
+        results = pool.map(_process_alignment, input_files)
+
+    sum_snp = defaultdict(int)
+
+    for pair_counts, _ in results:
+        for key, value in pair_counts.items():
+            sum_snp[key] += value
 
 SLC_path_1 = args.ID_TSV
 
@@ -133,6 +135,7 @@ strain_naams = list(df_SLC_1[1])
 df_mat = pd.DataFrame(0
                       , index=strain_naams
                       , columns=strain_naams
+                     , dtype=np.int64
                      )
 df_mat.index = strain_naams
 df_mat.columns = strain_naams
@@ -142,8 +145,12 @@ cbn = list(combinations(strain_naams,
                    ))
 for pairs in cbn:
     if (pairs[0], pairs[1]) in sum_snp_4_2.keys():
-        df_mat.loc[pairs[1], pairs[0]] = sum_snp_4_2[(pairs[0], pairs[1])]
+        value = int(round(sum_snp_4_2[(pairs[0], pairs[1])]))
+        df_mat.loc[pairs[1], pairs[0]] = value
+        df_mat.loc[pairs[0], pairs[1]] = value
     elif (pairs[1], pairs[0]) in sum_snp_4_2.keys():
-        df_mat.loc[(pairs[1], pairs[0])] = sum_snp_4_2[(pairs[1], pairs[0])]
+        value = int(round(sum_snp_4_2[(pairs[1], pairs[0])]))
+        df_mat.loc[pairs[1], pairs[0]] = value
+        df_mat.loc[pairs[0], pairs[1]] = value
 
 df_mat.iloc[1:, 0: -1].to_csv(args.output_csv)

--- a/src/TK_SNPmat.py
+++ b/src/TK_SNPmat.py
@@ -2,14 +2,15 @@ from Bio import SeqIO
 import pandas as pd
 
 import argparse
-import os
+from pathlib import Path
 
 from itertools import combinations
-from multiprocessing import Process, Manager
+from multiprocessing import Pool
+from collections import defaultdict
 
 import numpy as np
 
-from OrthoSLC import __version__, mission_spliter
+from OrthoSLC import __version__
 
 p = argparse.ArgumentParser(
     prog="python3 TK_SNPmat.py",
@@ -37,130 +38,86 @@ args, extras = p.parse_known_args()
 
 kaligned_path = args.input_path
 
-CONV_DICT = {
-    "A": [1.0, 0.0, 0.0, 0.0],
-    "T": [0.0, 1.0, 0.0, 0.0],
-    "C": [0.0, 0.0, 1.0, 0.0],
-    "G": [0.0, 0.0, 0.0, 1.0],
-    "Y": [0.0, 0.5, 0.5, 0.0],
-    "R": [0.5, 0.0, 0.0, 0.5],
-    "S": [0.0, 0.0, 0.5, 0.5],
-    "W": [0.5, 0.5, 0.0, 0.0],
-    "K": [0.0, 0.5, 0.0, 0.5],
-    "M": [0.5, 0.0, 0.5, 0.0],
-    "B": [0.0, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0],
-    "D": [1.0 / 3.0, 1.0 / 3.0, 0.0, 1.0 / 3.0],
-    "H": [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0, 0.0],
-    "V": [1.0 / 3.0, 0.0, 1.0 / 3.0, 1.0 / 3.0],
-    "N": [0.25, 0.25, 0.25, 0.25],
-    "-": [0.0, 0.0, 0.0, 0.0],
-}
+def _init_worker(base_path, species_order):
+    """Store shared configuration for worker processes."""
+    global _KALIGNED_PATH, _SPECIES_ORDER, _PAIR_INDEX
+
+    _KALIGNED_PATH = base_path
+    _SPECIES_ORDER = species_order
+    _PAIR_INDEX = [(i, j) for i in range(len(species_order))
+                   for j in range(i + 1, len(species_order))]
 
 
-def encode_sequence(sequence):
-    """Convert a DNA sequence to a flattened numerical representation."""
-
-    try:
-        encoded = np.array([CONV_DICT[base.upper()] for base in sequence], dtype=np.float32)
-    except KeyError as exc:
-        raise ValueError(f"Unsupported base '{exc.args[0]}' encountered in sequence.") from exc
-
-    return encoded.reshape(-1)
+def _encode_sequence(sequence: str) -> np.ndarray:
+    """Convert a nucleotide sequence into a numpy byte array."""
+    return np.frombuffer(sequence.upper().encode("ascii"), dtype="S1")
 
 
-def pairwise_l2_distance(vectors):
-    """Compute pairwise L2 distance matrix for the provided vectors."""
+def _process_alignment(filename: str):
+    """Compute pairwise SNP counts for a single alignment file."""
+    filepath = Path(_KALIGNED_PATH) / filename
+    fasta_records = SeqIO.to_dict(SeqIO.parse(filepath, "fasta"))
 
-    if not vectors:
-        return np.empty((0, 0), dtype=np.float32)
+    sequence_bytes = {}
+    for record_id, record in fasta_records.items():
+        if "-" not in record_id:
+            raise ValueError(
+                f"Record id '{record_id}' in '{filepath}' does not contain '-' separator."
+            )
+        species_id = record_id.split("-", 1)[0]
+        sequence_bytes[species_id] = _encode_sequence(str(record.seq))
 
-    mat = np.vstack(vectors).astype(np.float32)
-    sq_norms = np.sum(mat ** 2, axis=1, keepdims=True)
-    dist_sq = sq_norms - 2 * mat @ mat.T + sq_norms.T
-    np.maximum(dist_sq, 0, out=dist_sq)
-    return np.sqrt(dist_sq, out=dist_sq)
+    missing_species = [sid for sid in _SPECIES_ORDER if sid not in sequence_bytes]
+    if missing_species:
+        raise KeyError(
+            f"Alignment '{filepath}' is missing sequences for: {', '.join(missing_species)}"
+        )
 
-def distance_in_one_cluster(in_path_ls, 
-                            share_ls, 
-                            loop_ls, 
-                            total_len):
-    species_order = sorted({sid for sid_pair in loop_ls for sid in sid_pair})
+    seq_len_set = {len(seq) for seq in sequence_bytes.values()}
+    if len(seq_len_set) != 1:
+        raise ValueError(
+            f"Alignment '{filepath}' contains sequences with inconsistent lengths: {seq_len_set}"
+        )
 
-    for in_path in in_path_ls:
-        in_fasta = SeqIO.to_dict(SeqIO.parse(kaligned_path + '/' + in_path,
-                                             'fasta'))
+    ordered_matrix = np.vstack([sequence_bytes[sid] for sid in _SPECIES_ORDER])
+    diff_matrix = ordered_matrix[:, None, :] != ordered_matrix[None, :, :]
+    snp_matrix = diff_matrix.sum(axis=2, dtype=np.int32)
 
-        spe_dict = {x[0:x.index('-')]: x for x in in_fasta.keys()}
+    pair_counts = {
+        (_SPECIES_ORDER[i], _SPECIES_ORDER[j]): int(snp_matrix[i, j])
+        for i, j in _PAIR_INDEX
+    }
 
-        encoded_vectors = []
-        cluster_seq_len = None
-        for sid in species_order:
-            record_id = spe_dict.get(sid)
-            if record_id is None:
-                raise KeyError(f"Sequence for species '{sid}' missing in alignment '{in_path}'.")
-
-            seq = str(in_fasta[record_id].seq)
-            if cluster_seq_len is None:
-                cluster_seq_len = len(seq)
-
-            encoded_vectors.append(encode_sequence(seq))
-
-        distance_matrix = pairwise_l2_distance(encoded_vectors)
-        species_index = {sid: idx for idx, sid in enumerate(species_order)}
-
-        result_dict = {}
-
-        for pair in loop_ls:
-            idx_a = species_index[pair[0]]
-            idx_b = species_index[pair[1]]
-            result_dict[pair] = distance_matrix[idx_a, idx_b]
-
-        total_len.append(cluster_seq_len)
-        share_ls.append(result_dict)
+    return pair_counts, ordered_matrix.shape[1]
 
 if __name__ == '__main__':
     procc_num = int(args.resource_total)
-    
-    mission_ls = mission_spliter(os.listdir(kaligned_path), procc_num)
-    
-    manager = Manager()
-    return_dict_ls = manager.list()
-    len_ls = manager.list()
-    
-    a_fasta = SeqIO.parse(kaligned_path + '/' + os.listdir(kaligned_path)[0], 'fasta')
-    a_ls = [x.id[0: x.id.index('-')] for x in a_fasta]
-    a_ls.sort()
-    
-    par_ls = list(combinations(a_ls, 2))
-    
-    for submissions in mission_ls:
-    
-        jobs = []
 
-        p = Process(target = distance_in_one_cluster,
-                    args = (submissions, 
-                            return_dict_ls,
-                            par_ls,
-                            len_ls
-                           )
+    kaligned_dir = Path(kaligned_path)
+    input_files = sorted(
+        [f.name for f in kaligned_dir.iterdir() if f.is_file() and not f.name.startswith('.')]
+    )
 
-                   )
-        p.start()
-        jobs.append(p)
+    if not input_files:
+        raise FileNotFoundError(f"No alignment files found under '{kaligned_path}'.")
 
+    first_file = kaligned_dir / input_files[0]
+    species_ids = sorted(
+        record.id.split("-", 1)[0]
+        for record in SeqIO.parse(first_file, "fasta")
+    )
 
-    for z in jobs:
-        z.join()
-    return_dict_ls = list(return_dict_ls)
+    worker_count = max(1, min(procc_num, len(input_files)))
 
-#add up all the snp number
-sum_snp = {}
-for key in return_dict_ls[0]: #prepare a dict to save snp number
-    sum_snp[key] = 0
-    
-for i in return_dict_ls:
-    for key in sum_snp:
-        sum_snp[key] = sum_snp[key] + i[key]
+    with Pool(processes=worker_count, initializer=_init_worker,
+              initargs=(str(kaligned_dir), species_ids)) as pool:
+        results = pool.map(_process_alignment, input_files)
+
+    sum_snp = defaultdict(int)
+
+    for pair_counts, _ in results:
+        for key, value in pair_counts.items():
+            sum_snp[key] += value
 
 SLC_path_1 = args.ID_TSV
 
@@ -176,6 +133,7 @@ strain_naams = list(df_SLC_1[1])
 df_mat = pd.DataFrame(0
                       , index=strain_naams
                       , columns=strain_naams
+                     , dtype=np.int64
                      )
 df_mat.index = strain_naams
 df_mat.columns = strain_naams
@@ -185,8 +143,12 @@ cbn = list(combinations(strain_naams,
                    ))
 for pairs in cbn:
     if (pairs[0], pairs[1]) in sum_snp_4_2.keys():
-        df_mat.loc[pairs[1], pairs[0]] = sum_snp_4_2[(pairs[0], pairs[1])]
+        value = int(round(sum_snp_4_2[(pairs[0], pairs[1])]))
+        df_mat.loc[pairs[1], pairs[0]] = value
+        df_mat.loc[pairs[0], pairs[1]] = value
     elif (pairs[1], pairs[0]) in sum_snp_4_2.keys():
-        df_mat.loc[(pairs[1], pairs[0])] = sum_snp_4_2[(pairs[1], pairs[0])]
+        value = int(round(sum_snp_4_2[(pairs[1], pairs[0])]))
+        df_mat.loc[pairs[1], pairs[0]] = value
+        df_mat.loc[pairs[0], pairs[1]] = value
 
 df_mat.iloc[1:, 0: -1].to_csv(args.output_csv)


### PR DESCRIPTION
## Summary
- replace the per-pair SNP loop with a vectorised numpy implementation
- process each alignment file in parallel via a multiprocessing pool
- build the final SNP matrix with integer types and symmetric assignments to avoid dtype warnings

## Testing
- `python bins/TK_SNPmat.py -i OrthoSLC/tmp_test/kalign -o OrthoSLC/tmp_test/out.csv -T OrthoSLC/tmp_test/Step1_op.txt -u 4` *(fails: missing BioPython dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fc5420f7ec832984361062f9a48fcd